### PR TITLE
Adds FSRS bulk-loading cron job

### DIFF
--- a/job-queue-manager/fsrs-cron/tasks/main.yml
+++ b/job-queue-manager/fsrs-cron/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+- cron: name=PYTHONPATH env=yes value="{{ ansible_env.PYTHONPATH }}:/data-act/backend"
+- cron: name="sync fsrs data" minute="0" job="python /data-act/backend/dataactbroker/scripts/loadFSRS.py >> /tmp/fsrs.log"

--- a/job-queue-manager/site.yml
+++ b/job-queue-manager/site.yml
@@ -6,4 +6,5 @@
   - pull-repo
   - pip-install
   - copy-files
+  - fsrs-cron
   - run-app

--- a/job-queue-manager/yum-installs/tasks/main.yml
+++ b/job-queue-manager/yum-installs/tasks/main.yml
@@ -54,3 +54,6 @@
 - name: install python34 development libraries
   sudo: true
   yum: name=python34-devel
+- name: install cron
+  sudo: true
+  yum: name=cronie


### PR DESCRIPTION
FSRS data needs to be downloaded in chunks of 500 entries. To get us started,
this installs cron to the job manager and sets up a cron job to execute the
`loadFSRS` script. It's currently appending the results (a line or two per
run) to a tmp file, but that's only a temporary solution.

@klrBAH - this works for me on a centos vagrant box but I hacked out all of the configuration steps, so I'm not 100% positive it all works. I think you said I need to PR a separate branch, too? Also, no rush on this; whenever's convenient.