### PR TITLE
Fix a few errors with the FSRS cron job

### DIFF
--- a/job-queue-manager/fsrs-cron/tasks/main.yml
+++ b/job-queue-manager/fsrs-cron/tasks/main.yml
@@ -1,3 +1,3 @@
 ---
-- cron: name=PYTHONPATH env=yes value="{{ ansible_env.PYTHONPATH }}:/data-act/backend"
-- cron: name="sync fsrs data" minute="0" job="python /data-act/backend/dataactbroker/scripts/loadFSRS.py >> /tmp/fsrs.log"
+- cron: name="sync fsrs data" minute="0" user="ec2-user" job="PYTHONPATH='/data-act/backend' python3 /data-act/backend/dataactbroker/scripts/loadFSRS.py &>> /tmp/fsrs.log"
+  sudo: true

--- a/job-queue-manager/fsrs-cron/tasks/main.yml
+++ b/job-queue-manager/fsrs-cron/tasks/main.yml
@@ -1,3 +1,3 @@
 ---
-- cron: name="sync fsrs data" minute="0" user="ec2-user" job="PYTHONPATH='/data-act/backend' python3 /data-act/backend/dataactbroker/scripts/loadFSRS.py &>> /tmp/fsrs.log"
+- cron: name="sync fsrs data" minute="0" user="ec2-user" job="PYTHONPATH='/data-act/backend' env='{{ ENV }}' python3 /data-act/backend/dataactbroker/scripts/loadFSRS.py &>> /tmp/fsrs.log"
   sudo: true


### PR DESCRIPTION
Notably:
* Don't use ansible_env.PYTHONPATH; it'll crash if PYTHONPATH isn't available
* Don't use the `env=yes` flag (prefix the command instead) to avoid potential
  version issues
* Use python3 (python2 is installed as python)
* Redirect stderr to the log file as well
* Use sudo + a user to account for user mismatches
* Add the `env` var