### PR TITLE
Modify DOWNLOAD_ENV setting per environment

### DIFF
--- a/usaspending-deploy/usaspending-api-launch.yml
+++ b/usaspending-deploy/usaspending-api-launch.yml
@@ -159,6 +159,9 @@
         - { regexp: '^USASPENDING_AWS_REGION =.*',
             line: "USASPENDING_AWS_REGION = '{{ USASPENDING_AWS_REGION }}'" }
 
+        - { regexp: '^DOWNLOAD_ENV =.*',
+            line: "DOWNLOAD_ENV = '{{ DOWNLOAD_ENV }}'" }
+
         - { regexp: '^BULK_DOWNLOAD_S3_BUCKET_NAME =.*',
             line: "BULK_DOWNLOAD_S3_BUCKET_NAME = '{{ BULK_DOWNLOAD_S3_BUCKET_NAME }}'" }
 


### PR DESCRIPTION
# Note
This setting is currently only available on the sandbox environment but will be available on the other environments. Given ansible's behavior, if the `regexp` doesn't match a line in the file, it should ignore that task and move on.