### PR TITLE
Drop branch concat to static url path

### DIFF
--- a/usaspending-deploy/usaspending-api-launch.yml
+++ b/usaspending-deploy/usaspending-api-launch.yml
@@ -175,7 +175,7 @@
             line: "MONTHLY_DOWNLOAD_S3_BUCKET_NAME = '{{ MONTHLY_DOWNLOAD_S3_BUCKET_NAME }}'" }
 
         - { regexp: '\s*STATIC_URL =.*',
-            line: "STATIC_URL = '{{ STATIC_ASSETS_URL }}{{ BRANCH }}/'" }
+            line: "STATIC_URL = '{{ STATIC_ASSETS_URL }}'" }
 
         - { regexp: '^CFDA_BUCKET_NAME =.*',
             line: "CFDA_BUCKET_NAME = '{{ CFDA_BUCKET_NAME }}'" }


### PR DESCRIPTION
STATIC_ASSETS_URL should ignore this {{ branch }} concat nonsense and just be declared in the yml config.