### PR TITLE
Remote packer execution

### DIFF
--- a/usaspending-deploy/bulk-download/usaspending-bulk-download-launch.yml
+++ b/usaspending-deploy/bulk-download/usaspending-bulk-download-launch.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: "{{ HOST }}"
+- hosts: "localhost"
 
 # NOTE: This should run after usaspending-api-image.yml
 

--- a/usaspending-deploy/usaspending-api-image.yml
+++ b/usaspending-deploy/usaspending-api-image.yml
@@ -1,14 +1,14 @@
 #===============================  USASPENDING-API-IMAGE PLAYBOOK  ===============================#
 
 ---
-- hosts: "{{ HOST }}"
+- hosts: all
 
   become_method: sudo
-  user: ec2-user
+  remote_user: ec2-user
 
   vars:
     BRANCH: "master"
-    REPO: https://github.com/fedspendingtransparency/usaspending-api.git   
+    REPO: https://github.com/fedspendingtransparency/usaspending-api.git
     CODE_HOME: /data-act/backend
     REQ_DIR: "{{ CODE_HOME }}/requirements"
     ansible_python_interpreter: /usr/bin/python
@@ -30,26 +30,35 @@
 
     - name: checkout backend from git
       become: true
-      git: 
+      git:
         repo: "{{ REPO }}"
         version: "{{ BRANCH }}"
-        dest: /data-act/backend 
-        accept_hostkey: true 
+        dest: "{{ CODE_HOME }}"
+        accept_hostkey: true
         force: yes
-    
+
     - name: checkout usaspending-config from git
       become: true
-      git: 
+      git:
         repo: "git@github.com:fedspendingtransparency/usaspending-config.git"
         dest: /data-act/config
-        accept_hostkey: true 
-        force: yes 
+        accept_hostkey: true
+        force: yes
         key_file: /home/ec2-user/.ssh/id_rsa_usaspending_config
+
+    - name: pull repo - checkout build-tools repo from git
+      become: true
+      git:
+         repo: git@github.com:fedspendingtransparency/data-act-build-tools.git
+         dest: /data-act/build-tools
+         accept_hostkey: true
+         force: yes
+         key_file: /home/ec2-user/.ssh/id_rsa_usaspending_config
 
     - name: assign ownership of api to ec2-user
       become: true
       file:
-        path: /data-act/ 
+        path: /data-act/
         owner: ec2-user
         recurse: yes
 
@@ -59,44 +68,40 @@
         path: /tmp
         owner: ec2-user
         recurse: yes
-  
+
 #===============================  Install PIP Packages  ===============================#
 
     - name: update pip
-      become: true 
-      shell: pip3.5 install --upgrade pip 
+      become: true
+      shell: pip3.5 install --upgrade pip
 
     - name: install python packages based on requirements.txt
-      become: true 
+      become: true
       pip:
-        chdir: "{{ REQ_DIR }}"
-        requirements: requirements.txt
+        requirements: "{{ REQ_DIR }}/requirements.txt"
         executable: pip3.5
 
     - name: install python packages based on caching_requirements.txt
-      become: true 
+      become: true
       pip:
-        chdir: "{{ REQ_DIR }}"
-        requirements: caching_requirements.txt
+        requirements: "{{ REQ_DIR }}/caching_requirements.txt"
         executable: pip3.5
 
     - name: install python packages based on server_requirements.txt
       become: true
       pip:
-        chdir: "{{ REQ_DIR }}"
-        requirements: server_requirements.txt
+        requirements: "{{ REQ_DIR }}/server_requirements.txt"
         executable: pip3.5
 
     - name: install python packages based on legacy_requirements.txt
       become: true
       pip:
-        chdir: "{{ REQ_DIR }}"
-        requirements: legacy_requirements.txt
+        requirements: "{{ REQ_DIR }}/legacy_requirements.txt"
         executable: pip2
 
     - name: ensure the correct directory structure for tmp nginx files
       become: true
-      file: 
+      file:
         path: /var/lib/nginx/tmp
         state: directory
         owner: ec2-user
@@ -105,7 +110,7 @@
 
     - name: set starting directory to CODE_HOME
       become: true
-      lineinfile: 
+      lineinfile:
         dest: /home/ec2-user/.bashrc
         line: "cd {{ CODE_HOME }}"
         insertafter: EOF
@@ -113,24 +118,24 @@
 #===============================  Configure DataDog Key  ===============================#
 
     - name: copy datadog_key from S3
-      become: true 
-      shell: "aws s3 cp s3://da-config/shared/datadog_key.yml /etc/ --region us-gov-west-1"
+      shell: "aws s3 cp s3://da-config/shared/datadog_key /data-act/config/ --region us-gov-west-1"
 
-    - name: load datadog_key var
-      include_vars: /etc/datadog_key.yml
+    - name: save the contents of datadog_key file
+      shell: cat "/data-act/config/datadog_key"
+      register: dd_key
 
     - name: add Datadog license key to datadog.yaml
-      become: true
       lineinfile:
         dest: /data-act/config/deploy/datadog.yaml
         regexp: '\s*api_key: .*'
-        line: "api_key: {{ DD_KEY }}"
+        line: "api_key: {{ dd_key.stdout }}"
 
     - name: copy datadog.yml to it's home location
       become: true
-      copy: 
+      copy:
         src: /data-act/config/deploy/datadog.yaml
         dest: /etc/datadog-agent/datadog.yaml
+        remote_src: true
 
 #===============================  Logrotate  ===============================#
 

--- a/usaspending-deploy/usaspending-api-image.yml
+++ b/usaspending-deploy/usaspending-api-image.yml
@@ -50,7 +50,6 @@
       become: true
       git:
          repo: git@github.com:fedspendingtransparency/data-act-build-tools.git
-         version: remote-packer
          dest: /data-act/build-tools
          accept_hostkey: true
          force: yes

--- a/usaspending-deploy/usaspending-api-image.yml
+++ b/usaspending-deploy/usaspending-api-image.yml
@@ -50,6 +50,7 @@
       become: true
       git:
          repo: git@github.com:fedspendingtransparency/data-act-build-tools.git
+         version: remote-packer
          dest: /data-act/build-tools
          accept_hostkey: true
          force: yes

--- a/usaspending-deploy/usaspending-api-image.yml
+++ b/usaspending-deploy/usaspending-api-image.yml
@@ -131,7 +131,7 @@
         regexp: '\s*api_key: .*'
         line: "api_key: {{ dd_key.stdout }}"
 
-    - name: copy datadog.yml to it's home location
+    - name: copy datadog.yml to its home location
       become: true
       copy:
         src: /data-act/config/deploy/datadog.yaml

--- a/usaspending-deploy/usaspending-api-launch.yml
+++ b/usaspending-deploy/usaspending-api-launch.yml
@@ -6,12 +6,10 @@
 #  - You MUST provide a DOMAIN_NAME for ALLOWED_HOSTS and SSL           #
 #=======================================================================#
 
-
 ---
-- hosts: "{{ HOST }}"
-
-  become_method: sudo
+- hosts: "localhost"
   user: ec2-user
+  become_method: sudo
 
   vars:
     ALLOWED_HOSTS: "{{ ALLOWED_HOSTS }}"

--- a/usaspending-deploy/usaspending-deploy.py
+++ b/usaspending-deploy/usaspending-deploy.py
@@ -5,6 +5,7 @@ import os
 import json
 import argparse
 import sys
+import shutil
 from subprocess import Popen, PIPE, STDOUT, call
 
 EXIT_CODE = 0

--- a/usaspending-deploy/usaspending-deploy.py
+++ b/usaspending-deploy/usaspending-deploy.py
@@ -197,8 +197,8 @@ def update_packer_spec(packer_file='packer.json', base_ami='', environment='stag
 
     if environment == 'dev' or environment == 'sandbox':
         packer_data['builders'][0]['tags']['environment'] = environment
-        packer_data['provisioners'][0]['extra_arguments'] = "--extra-vars 'BRANCH={}'".format(environment)
-
+        packer_data['provisioners'][0]['extra_arguments'] = ["--extra-vars",
+         "BRANCH={} HOST=local".format(environment) ]
     packer_json = open(packer_file, "w+")
     packer_json.write(json.dumps(packer_data))
     packer_json.close()

--- a/usaspending-deploy/usaspending-deploy.py
+++ b/usaspending-deploy/usaspending-deploy.py
@@ -82,7 +82,6 @@ def deploy():
 
 
     if optionsDict["sandbox"] or optionsDict["dev"] or optionsDict["staging"]:
-
         # Get Base AMI, Update Packer file
         print('Retrieving base AMI...')
         base_ami = conn.get_all_images(filters={
@@ -118,9 +117,11 @@ def deploy():
             print('Done.')
         else:
             print('No matching old AMIs. Skipping tag update...')
-
+  ###########################
+  #   TF Build - NonProd    #
+  ###########################
         # Add new AMI to Terraform variables
-        update_tf_ami(new_instance_ami, tfvar_file)
+        update_tf_ami("ami-ae148ecf", tfvar_file)
 
     elif optionsDict["prod"]:
         # Get current Staging AMI

--- a/usaspending-deploy/usaspending-deploy.py
+++ b/usaspending-deploy/usaspending-deploy.py
@@ -14,7 +14,6 @@ def deploy():
 
     # This tf_var file is expected to be copied from an external source
     tfvar_file       = 'usaspending-vars.tf.json'
-    # tf_exec_path     = 'terraform'
     tf_exec_path     = '/terraform/latest/terraform'
     tf_file          = 'usaspending-deploy.tf'
 

--- a/usaspending-deploy/usaspending-deploy.py
+++ b/usaspending-deploy/usaspending-deploy.py
@@ -121,7 +121,7 @@ def deploy():
   #   TF Build - NonProd    #
   ###########################
         # Add new AMI to Terraform variables
-        update_tf_ami("ami-ae148ecf", tfvar_file)
+        update_tf_ami(new_instance_ami, tfvar_file)
 
     elif optionsDict["prod"]:
         # Get current Staging AMI

--- a/usaspending-deploy/usaspending-deploy.py
+++ b/usaspending-deploy/usaspending-deploy.py
@@ -188,11 +188,13 @@ def update_packer_spec(packer_file='packer.json', base_ami='', environment='stag
     packer_json.close()
 
     packer_data['builders'][0]['source_ami'] = base_ami
+    packer_data['builders'][0]['tags']['environment'] = environment
 
-    if environment == 'dev' or environment == 'sandbox':
-        packer_data['builders'][0]['tags']['environment'] = environment
-        packer_data['provisioners'][0]['extra_arguments'] = ["--extra-vars",
-         "BRANCH={} HOST=local".format(environment) ]
+    if environment == 'staging':
+        environment = 'stg'    
+    packer_data['provisioners'][0]['extra_arguments'] = ["--extra-vars",
+     "BRANCH={} HOST=local".format(environment) ]
+    
     packer_json = open(packer_file, "w+")
     packer_json.write(json.dumps(packer_data))
     packer_json.close()

--- a/usaspending-deploy/usaspending-deploy.py
+++ b/usaspending-deploy/usaspending-deploy.py
@@ -51,10 +51,6 @@ def deploy():
         print ("No environment specified. Please include an argument: --sandbox, --dev, --staging, or --prod")
         sys.exit(1)
 
-  ###########################
-  #      Packer Build       #
-  ###########################
-
   # Sandbox, dev, and staging are all built the same way: packer, then create TF resources
   # Prod pulls the same staging AMI that packer creates, and alters the launch config/AWS names
 
@@ -109,7 +105,6 @@ def deploy():
         new_instance_ami = ami_line[ami_line.find('ami-'):ami_line.find('ami-')+12]
         print('Done. New AMI created: ' + new_instance_ami)
 
-
         # Set current=False tag for old AMIs
         if old_instance_amis:
             print('Done. Setting current tag to False on old instance AMIs: \n' + '\n'.join(map(str, old_instance_amis)) )
@@ -117,9 +112,6 @@ def deploy():
             print('Done.')
         else:
             print('No matching old AMIs. Skipping tag update...')
-  ###########################
-  #   TF Build - NonProd    #
-  ###########################
         # Add new AMI to Terraform variables
         update_tf_ami(new_instance_ami, tfvar_file)
 

--- a/usaspending-deploy/usaspending-deploy.py
+++ b/usaspending-deploy/usaspending-deploy.py
@@ -197,7 +197,7 @@ def update_packer_spec(packer_file='packer.json', base_ami='', environment='stag
 
     if environment == 'dev' or environment == 'sandbox':
         packer_data['builders'][0]['tags']['environment'] = environment
-        packer_data['provisioners'][0]['extra_arguments'] = "--extra-vars 'BRANCH={} HOST=local'".format(environment)
+        packer_data['provisioners'][0]['extra_arguments'] = "--extra-vars 'BRANCH={}'".format(environment)
 
     packer_json = open(packer_file, "w+")
     packer_json.write(json.dumps(packer_data))

--- a/usaspending-deploy/usaspending-deploy.py
+++ b/usaspending-deploy/usaspending-deploy.py
@@ -112,6 +112,7 @@ def deploy():
             print('Done.')
         else:
             print('No matching old AMIs. Skipping tag update...')
+
         # Add new AMI to Terraform variables
         update_tf_ami(new_instance_ami, tfvar_file)
 
@@ -149,7 +150,6 @@ def deploy():
                        '-backend-config=region='+tf_aws_region])
     real_time_command([tf_exec_path, 'plan',  '-input=false', '-out=' + tf_file])
     real_time_command([tf_exec_path, 'apply', '-input=false', tf_file])
-
     global EXIT_CODE
     if EXIT_CODE != 0:
         print('Exiting with a code of {}'.format(EXIT_CODE))


### PR DESCRIPTION
Summary: 
Execute packer scripts with local ansible playbooks instead of copying it to the host. 

Changes: 
- change hosts variable in launch playbooks to `localhosts`
- changes in image playbooks to make it work with local packer execution
- some code clean up in deploy python scripts. 

NOTE: the build-tools branch in the image ansible playbooks needs to be removed after merging. 