### PR TITLE
Change the execpath of terraform and packer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,8 +33,4 @@ RUN unzip /root/workspace/terraform_${TERRAFORM_VERSION}_linux_amd64.zip -d /opt
 RUN ln -s /opt/terraform/terraform /usr/local/bin/terraform
 
 # install pip packages
-RUN pip3 install boto3 sh argparse
-
-# set the symlink to the current packer and terraform exec_path
-RUN mkdir -p /packer && mkdir -p /terraform/latest/
-RUN ln -s /opt/packer/packer /packer/packerio && ln -s /opt/terraform/terraform /terraform/latest/terraform
+RUN pip3.6 install boto3 sh argparse

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,4 +33,4 @@ RUN unzip /root/workspace/terraform_${TERRAFORM_VERSION}_linux_amd64.zip -d /opt
 RUN ln -s /opt/terraform/terraform /usr/local/bin/terraform
 
 # install pip packages
-RUN pip3.6 install boto3 sh argparse
+RUN pip install boto3 sh argparse

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,4 +33,4 @@ RUN unzip /root/workspace/terraform_${TERRAFORM_VERSION}_linux_amd64.zip -d /opt
 RUN ln -s /opt/terraform/terraform /usr/local/bin/terraform
 
 # install pip packages
-RUN pip install boto3 sh argparse
+RUN pip3 install boto3 sh argparse

--- a/broker-deploy/broker-deploy.py
+++ b/broker-deploy/broker-deploy.py
@@ -18,8 +18,8 @@ def deploy():
     packer_file = 'broker-packer.json'
     tfvar_file = 'broker-vars.tf.json'
     tf_file = 'broker-deploy.tf'
-    packer_exec_path = '/packer/packerio'
-    tf_exec_path = '/terraform/latest/terraform'
+    packer_exec_path = 'packer'
+    tf_exec_path = 'terraform'
 
     parser = argparse.ArgumentParser()
 

--- a/usaspending-deploy/bulk-download/usaspending-bulk-download-deploy.py
+++ b/usaspending-deploy/bulk-download/usaspending-bulk-download-deploy.py
@@ -13,7 +13,7 @@ def deploy():
     # This tf_var file is expected to be copied from an external source
     tfvar_file   = 'usaspending-bulk-download-vars.tf.json'
 
-    tf_exec_path = '/terraform/latest/terraform'
+    tf_exec_path = 'terraform'
     tf_file      = 'usaspending-bulk-download-deploy.tf'
 
     # Set connection

--- a/usaspending-deploy/usaspending-deploy.py
+++ b/usaspending-deploy/usaspending-deploy.py
@@ -16,10 +16,10 @@ def deploy():
 
     # This tf_var file is expected to be copied from an external source
     tfvar_file       = 'usaspending-vars.tf.json'
-    tf_exec_path     = '/terraform/latest/terraform'
+    tf_exec_path     = 'terraform'
     tf_file          = 'usaspending-deploy.tf'
 
-    packer_exec_path = '/packer/packerio'
+    packer_exec_path = 'packer'
     packer_file      = 'usaspending-packer.json'
 
     # Set connection


### PR DESCRIPTION
The execpath is just `terraform` and `packer` now. 