### PR TITLE
Broker deploy docker fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,4 +33,4 @@ RUN unzip /root/workspace/terraform_${TERRAFORM_VERSION}_linux_amd64.zip -d /opt
 RUN ln -s /opt/terraform/terraform /usr/local/bin/terraform
 
 # install pip packages
-RUN pip3 install boto3 botocore sh argparse
+RUN pip3 install boto3 sh argparse

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,4 +33,4 @@ RUN unzip /root/workspace/terraform_${TERRAFORM_VERSION}_linux_amd64.zip -d /opt
 RUN ln -s /opt/terraform/terraform /usr/local/bin/terraform
 
 # install pip packages
-RUN pip3 install boto3 sh argparse
+RUN pip3 install boto3 botocore sh argparse

--- a/broker-deploy/app-instance-image.yml
+++ b/broker-deploy/app-instance-image.yml
@@ -1,5 +1,3 @@
-# ========================= BROKER-API-IMAGE PLAYBOOK =========================#
-
 ---
 - hosts: all
   remote_user: ec2-user
@@ -12,29 +10,29 @@
 
   tasks:
 
+    - name: Get boto3/botocore for aws modules
+      become: true
+      pip:
+        name: ['boto3', 'botocore']
+        executable: pip2
+
     # ===================== Copy Git Creds from S3 Bucket =====================#
 
     - name: Pull repo - copy broker git credentials from S3 Bucket
       become: true
       aws_s3:
         bucket: da-config
-        object: /id_rsa_broker_config
+        object: /broker/id_rsa_broker_config
         dest: /home/ec2-user/.ssh/id_rsa_broker_config
         region: us-gov-west-1
         mode: get
 
-    - name: Change ownership of /home/ec2-user.ssh/
-      become: true
-      file:
-        path: /home/ec2-user/.ssh/
-        owner: ec2-user
-        group: ec2-user
-        recurse: "yes"
-
-    - name: Change mode for the id_rsa_broker_config
+    - name: Set permissions/owner of broker git credentials
       become: true
       file:
         path: /home/ec2-user/.ssh/id_rsa_broker_config
+        owner: ec2-user
+        group: ec2-user
         mode: 0400
 
     # ========================= Git Checkout ========================#
@@ -110,24 +108,23 @@
       aws_s3:
         bucket: da-config
         object: /shared/datadog_key.yml
-        dest: /etc/datadog_key.yml
+        dest: /data-act/config/datadog_key
         region: us-gov-west-1
         mode: get
 
-    - name: Load datadog_key var
-      include_vars: /etc/datadog_key.yml
+    - name: save the contents of datadog_key file
+      shell: cat "/data-act/config/datadog_key"
+      register: dd_key
 
-    - name: Add Datadog license key to datadog.yaml
-      become: true
+    - name: add Datadog license key to datadog.yaml
       lineinfile:
         dest: /data-act/config/datadog/datadog.yaml
         regexp: '\s*api_key: .*'
-        line: "api_key: {{ DD_KEY }}"
+        line: "api_key: {{ dd_key.stdout }}"
 
-    - name: Copy datadog.yml to it's home location
+    - name: copy datadog.yml to its home location
       become: true
       copy:
         src: /data-act/config/datadog/datadog.yaml
         dest: /etc/datadog-agent/datadog.yaml
-
-# ======================== EOF ========================#
+        remote_src: true

--- a/broker-deploy/app-instance-image.yml
+++ b/broker-deploy/app-instance-image.yml
@@ -19,7 +19,6 @@
     # ===================== Copy Git Creds from S3 Bucket =====================#
 
     - name: Pull repo - copy broker git credentials from S3 Bucket
-      become: true
       aws_s3:
         bucket: da-config
         object: /broker/id_rsa_broker_config
@@ -31,8 +30,6 @@
       become: true
       file:
         path: /home/ec2-user/.ssh/id_rsa_broker_config
-        owner: ec2-user
-        group: ec2-user
         mode: 0400
 
     # ========================= Git Checkout ========================#

--- a/broker-deploy/app-instance-image.yml
+++ b/broker-deploy/app-instance-image.yml
@@ -56,6 +56,7 @@
       become: true
       git:
         repo: git@github.com:fedspendingtransparency/data-act-build-tools.git
+        version: broker-deploy-docker-fix
         dest: /data-act/build-tools
         accept_hostkey: true
         force: "yes"

--- a/broker-deploy/app-instance-image.yml
+++ b/broker-deploy/app-instance-image.yml
@@ -56,7 +56,6 @@
       become: true
       git:
         repo: git@github.com:fedspendingtransparency/data-act-build-tools.git
-        version: broker-deploy-docker-fix
         dest: /data-act/build-tools
         accept_hostkey: true
         force: "yes"

--- a/broker-deploy/app-instance-launch.yml
+++ b/broker-deploy/app-instance-launch.yml
@@ -96,12 +96,12 @@
 
     # ===================== SSL Certs (not used for Validator) =====================#
 
-    - name: copy public.pem from S3 Bucket
+    - name: Copy public.pem from S3 Bucket
       when: APP == "broker"
       become: true
       shell: "aws s3 cp s3://usaspending-ssl/{{ vars['envs'][BRANCH]['domain'] }}/public.pem /etc/cert.pem --region us-gov-west-1"
 
-    - name: copy private.pem from S3 Bucket
+    - name: Copy private.pem from S3 Bucket
       when: APP == "broker"
       become: true
       shell: "aws s3 cp s3://usaspending-ssl/{{ vars['envs'][BRANCH]['domain'] }}/private.pem /etc/cert.key --region us-gov-west-1"

--- a/broker-deploy/app-instance-launch.yml
+++ b/broker-deploy/app-instance-launch.yml
@@ -96,25 +96,15 @@
 
     # ===================== SSL Certs (not used for Validator) =====================#
 
-    - name: Copy public.pem from S3 Bucket
+    - name: copy public.pem from S3 Bucket
       when: APP == "broker"
       become: true
-      aws_s3:
-        bucket: usaspending-ssl
-        object: /{{ vars['envs'][BRANCH]['domain'] }}/public.pem
-        dest: /etc/cert.pem
-        region: us-gov-west-1
-        mode: get
+      shell: "aws s3 cp s3://usaspending-ssl/{{ vars['envs'][BRANCH]['domain'] }}/public.pem /etc/cert.pem --region us-gov-west-1"
 
-    - name: Copy private.pem from S3 Bucket
+    - name: copy private.pem from S3 Bucket
       when: APP == "broker"
       become: true
-      aws_s3:
-        bucket: usaspending-ssl
-        object: /{{ vars['envs'][BRANCH]['domain'] }}/private.pem
-        dest: /etc/cert.key
-        region: us-gov-west-1
-        mode: get
+      shell: "aws s3 cp s3://usaspending-ssl/{{ vars['envs'][BRANCH]['domain'] }}/private.pem /etc/cert.key --region us-gov-west-1"
 
     - name: Assign ownership of cert.pem to ec2-user
       when: APP == "broker"


### PR DESCRIPTION
- Bug in the `aws_s3` module definition with the key path.
- Requires boto3/core installed for the ansible python version
- Datadog module code was written before remote packer execution
- Consolidated permissions
- Pulling certs from S3 using command line instead of the module, because the bucket policies are intended to ONLY access the prod or non-prod envs.