### PR TITLE
cannot use BRANCH environment variable when it does not exist

### DIFF
--- a/usaspending-deploy/bulk-download/usaspending-bulk-download-launch.yml
+++ b/usaspending-deploy/bulk-download/usaspending-bulk-download-launch.yml
@@ -72,7 +72,7 @@
 
     - name: disable datadog apm if env is sandbox or dev
       become: true
-      when: BRANCH == "dev" or BRANCH == "sandbox"
+      when: ANSIBLE_VARS_ENV == "dev" or ANSIBLE_VARS_ENV == "sandbox"
       lineinfile:
         dest: "/etc/datadog-agent/datadog.yaml"
         regexp: "^  enabled: true"


### PR DESCRIPTION
None of the Bulk Download instances have worked in the past couple days due to the ansible script failing at this task. 

This patches that, will deploy to production.