### PR TITLE
Remove CFDA vars

### DIFF
--- a/usaspending-deploy/usaspending-api-launch.yml
+++ b/usaspending-deploy/usaspending-api-launch.yml
@@ -182,15 +182,6 @@
         - { regexp: '\s*STATIC_URL =.*',
             line: "STATIC_URL = '{{ STATIC_ASSETS_URL }}'" }
 
-        - { regexp: '^CFDA_BUCKET_NAME =.*',
-            line: "CFDA_BUCKET_NAME = '{{ CFDA_BUCKET_NAME }}'" }
-
-        - { regexp: '^CFDA_REGION =.*',
-            line: "CFDA_REGION = '{{ CFDA_REGION }}'" }
-
-        - { regexp: '^CFDA_FILE_PATH =.*',
-            line: "CFDA_FILE_PATH = '{{ CFDA_FILE_PATH }}'" }
-
     - name: turn debug off in production or staging
       when: BRANCH == 'master' or BRANCH == 'stg'
       lineinfile:


### PR DESCRIPTION
Removing unnecessary CFDA vars.

`usaspending-api` PR:
https://github.com/fedspendingtransparency/usaspending-api/pull/1714

Wait for Sprint 78 to reach production