### PR TITLE
Supervisord upgrade conditional

### DIFF
--- a/broker-deploy/app-instance-image.yml
+++ b/broker-deploy/app-instance-image.yml
@@ -92,7 +92,12 @@
         requirements: server_requirements.txt
         executable: pip3.5
 
-    - name: Install python packages based on legacy_requirements.txt
+    - name: check if requirements.txt (Python 3) defines a supervisor version
+      shell: cat /data-act/backend/requirements.txt | grep supervisor || true
+      register: requirements_out
+
+    - name: only install "legacy" if requirements.txt doesn't define supervisor
+      when: requirements_out.stdout.find('supervisor') == -1
       become: true
       pip:
         chdir: /data-act/backend

--- a/broker-deploy/app-instance-image.yml
+++ b/broker-deploy/app-instance-image.yml
@@ -92,12 +92,12 @@
         requirements: server_requirements.txt
         executable: pip3.5
 
-    - name: check if requirements.txt (Python 3) defines a supervisor version
-      shell: cat /data-act/backend/requirements.txt | grep supervisor || true
-      register: requirements_out
+    - name: check if server_requirements.txt (Python 3) defines a supervisor version
+      shell: cat /data-act/backend/server_requirements.txt | grep supervisor || true
+      register: server_req_out
 
-    - name: only install "legacy" if requirements.txt doesn't define supervisor
-      when: requirements_out.stdout.find('supervisor') == -1
+    - name: only install "legacy" if server_requirements.txt doesn't define supervisor
+      when: server_req_out.stdout.find('supervisor') == -1
       become: true
       pip:
         chdir: /data-act/backend

--- a/usaspending-deploy/usaspending-api-image.yml
+++ b/usaspending-deploy/usaspending-api-image.yml
@@ -98,7 +98,7 @@
       shell: cat "{{ REQ_DIR }}/requirements.txt" | grep supervisor || true
       register: requirements_out
 
-    - name: only install "legacy" if the requirements.txt doesn't define supervisor
+    - name: only install "legacy" if requirements.txt doesn't define supervisor
       when: requirements_out.stdout.find('supervisor') == -1
       become: true
       pip:

--- a/usaspending-deploy/usaspending-api-image.yml
+++ b/usaspending-deploy/usaspending-api-image.yml
@@ -95,6 +95,7 @@
         executable: pip3.5
 
     - name: install python packages based on legacy_requirements.txt
+      when: BRANCH == "staging" or BRANCH == "master"
       become: true
       pip:
         requirements: "{{ REQ_DIR }}/legacy_requirements.txt"
@@ -146,5 +147,3 @@
         src:  /data-act/config/deploy/elk/usaspending-api.logrotate
         dest: /etc/logrotate.d/usaspending-api
         remote_src: true
-
-#===============================  EOF  ===============================#

--- a/usaspending-deploy/usaspending-api-image.yml
+++ b/usaspending-deploy/usaspending-api-image.yml
@@ -94,12 +94,12 @@
         requirements: "{{ REQ_DIR }}/server_requirements.txt"
         executable: pip3.5
 
-    - name: check if requirements.txt (Python 3) defines a supervisor version
-      shell: cat "{{ REQ_DIR }}/requirements.txt" | grep supervisor || true
-      register: requirements_out
+    - name: check if server_requirements.txt (Python 3) defines a supervisor version
+      shell: cat "{{ REQ_DIR }}/server_requirements.txt" | grep supervisor || true
+      register: server_req_out
 
-    - name: only install "legacy" if requirements.txt doesn't define supervisor
-      when: requirements_out.stdout.find('supervisor') == -1
+    - name: only install "legacy" if server_requirements.txt doesn't define supervisor
+      when: server_req_out.stdout.find('supervisor') == -1
       become: true
       pip:
         requirements: "{{ REQ_DIR }}/legacy_requirements.txt"

--- a/usaspending-deploy/usaspending-api-image.yml
+++ b/usaspending-deploy/usaspending-api-image.yml
@@ -94,8 +94,12 @@
         requirements: "{{ REQ_DIR }}/server_requirements.txt"
         executable: pip3.5
 
-    - name: install python packages based on legacy_requirements.txt
-      when: BRANCH == "staging" or BRANCH == "master"
+    - name: check if requirements.txt (Python 3) defines a supervisor version
+      shell: cat "{{ REQ_DIR }}/requirements.txt" | grep supervisor || true
+      register: requirements_out
+
+    - name: only install "legacy" if the requirements.txt doesn't define supervisor
+      when: requirements_out.stdout.find('supervisor') == -1
       become: true
       pip:
         requirements: "{{ REQ_DIR }}/legacy_requirements.txt"


### PR DESCRIPTION
To support updating of supervisor without disrupting other deployments, just check to see if supervisor is specified in the non-legacy `server_requirements.txt`.

Remove this conditional following the merging of both upgrades to master.