### PR TITLE
Override HOST value in usaspending-api in order to allow for permalinks.

### DIFF
--- a/usaspending-deploy/usaspending-api-image.yml
+++ b/usaspending-deploy/usaspending-api-image.yml
@@ -46,7 +46,7 @@
       become: true
       git:
         repo: "{{ REPO }}"
-        version: "mod/dev-3841-add-url-to-downloads"
+        version: "{{ BRANCH }}"
         dest: "{{ CODE_HOME }}"
         accept_hostkey: true
         force: yes
@@ -65,7 +65,6 @@
       git:
         repo: git@github.com:fedspendingtransparency/data-act-build-tools.git
         dest: /data-act/build-tools
-        version: "config/permalink"
         accept_hostkey: true
         force: yes
         key_file: /home/ec2-user/.ssh/id_rsa_usaspending_config

--- a/usaspending-deploy/usaspending-api-image.yml
+++ b/usaspending-deploy/usaspending-api-image.yml
@@ -46,7 +46,7 @@
       become: true
       git:
         repo: "{{ REPO }}"
-        version: "{{ BRANCH }}"
+        version: "mod/dev-3841-add-url-to-downloads"
         dest: "{{ CODE_HOME }}"
         accept_hostkey: true
         force: yes

--- a/usaspending-deploy/usaspending-api-image.yml
+++ b/usaspending-deploy/usaspending-api-image.yml
@@ -65,6 +65,7 @@
       git:
         repo: git@github.com:fedspendingtransparency/data-act-build-tools.git
         dest: /data-act/build-tools
+        version: "config/permalink"
         accept_hostkey: true
         force: yes
         key_file: /home/ec2-user/.ssh/id_rsa_usaspending_config

--- a/usaspending-deploy/usaspending-api-launch.yml
+++ b/usaspending-deploy/usaspending-api-launch.yml
@@ -224,6 +224,13 @@
           dest: "{{ CODE_HOME }}/usaspending_api/settings.py"
           regexp: '\s*HOST =.*'
           line: "HOST = '{{ DOMAIN }}'"
+          
+    - name: API | add host for permalink
+      when: BUILD_TYPE == 'bulk-download'
+      lineinfile:
+          dest: "{{ CODE_HOME }}/usaspending_api/settings.py"
+          regexp: '\s*HOST =.*'
+          line: "HOST = '{{ DOMAIN }}'"
 
     - name: API | cache settings (staging/prod, elasticache)
       when: BRANCH in ['master','stg'] and BUILD_TYPE == 'api'

--- a/usaspending-deploy/usaspending-api-launch.yml
+++ b/usaspending-deploy/usaspending-api-launch.yml
@@ -217,6 +217,13 @@
         dest: "{{ CODE_HOME }}/usaspending_api/settings.py"
         regexp: '\s*DEBUG =.*'
         line: "DEBUG = False"
+        
+    - name: API | add host for permalink
+      when: BUILD_TYPE == 'api'
+      lineinfile:
+          dest: "{{ CODE_HOME }}/usaspending_api/settings.py"
+          regexp: '\s*HOST =.*'
+          line: "HOST = '{{ DOMAIN }}'"
 
     - name: API | cache settings (staging/prod, elasticache)
       when: BRANCH in ['master','stg'] and BUILD_TYPE == 'api'


### PR DESCRIPTION
Follows up on api changes made in https://github.com/fedspendingtransparency/usaspending-api/pull/2151