### PR TITLE
[OPS-1194] Upgrade Terraform to version 0.12.24

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,13 @@
 
 FROM centos:latest
 
-ENV PACKER_VERSION 1.4.0
-ENV ANSIBLE_VERSION 2.8.3
-ENV TERRAFORM_VERSION 0.12.3
+ARG packer_version_arg=1.4.0
+ARG ansible_version_arg=2.8.3
+ARG terraform_version_arg=0.12.3
+
+ENV PACKER_VERSION=${packer_version_arg}
+ENV ANSIBLE_VERSION=${ansible_version_arg}
+ENV TERRAFORM_VERSION=${terraform_version_arg}
 
 RUN yum update -y && \
     yum install -y wget && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM centos:latest
 
 ARG packer_version_arg=1.4.0
 ARG ansible_version_arg=2.8.3
-ARG terraform_version_arg=0.12.3
+ARG terraform_version_arg=0.12.24
 
 ENV PACKER_VERSION=${packer_version_arg}
 ENV ANSIBLE_VERSION=${ansible_version_arg}


### PR DESCRIPTION
Change the default version so that 0.12.24 is used for deployments

NOTES:
- [ ] Depends on https://github.com/fedspendingtransparency/data-act-build-tools/pull/234, `Do Not Merge` until that one has been merged

BEFORE MERGING:
- [ ] Test on this branch with:
```
docker build -t data-act-build-tools .

docker run -i --rm=true -v $(pwd):/tmp -w /tmp data-act-build-tools /bin/sh -c "terraform fmt -check -diff -recursive"

docker run -i --rm=true -v $(pwd):/tmp -w /tmp data-act-build-tools \
  /bin/sh -c \
  "cd broker-deploy; \
  terraform init -backend=false; \
  terraform validate"

docker run -i --rm=true -v $(pwd):/tmp -w /tmp data-act-build-tools \
  /bin/sh -c \
  "cd usaspending-deploy; \
  terraform init -backend=false; \
  terraform validate"
```