### PR TITLE
Upgrade packer to 1.4.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 FROM centos:latest
 
-ARG packer_version_arg=1.4.0
+ARG packer_version_arg=1.4.3
 ARG ansible_version_arg=2.8.3
 ARG terraform_version_arg=0.12.24
 


### PR DESCRIPTION
This is required to support the `galaxy_file` argument for the ansible packer provisioner, which is being used for logstash ami builds in `data-act-config`.