### PR TITLE
using centos:latest (now 8), building with no previously cached layers fails

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Contains packer/terraform/ansible dependencies in order to run the various *-deploy.py scripts in a container
 
-FROM centos:latest
+FROM centos:7
 
 ARG packer_version_arg=1.4.3
 ARG ansible_version_arg=2.8.3


### PR DESCRIPTION
# Summary

`centost:latest` is now 8 and building either for the first time or with no previously cached base image fails.

## Reproduction Steps

if building for the first time:
```shell
docker build .
```

if building when you already have the centos image layer cached:
```shell
docker build --no-cache .
```

we reference rpms that are specific to centos 7. We need to explicitly call out `centos:7` as the base image now that 8 has been released.

In the future we also need to sort out the python versions and the equivalent epel repo location for `centos:8`.