### PR TITLE
Set DEFAULT_DB_TIMEOUT_IN_SECONDS in settings.py

### DIFF
--- a/usaspending-deploy/usaspending-api-launch.yml
+++ b/usaspending-deploy/usaspending-api-launch.yml
@@ -178,12 +178,6 @@
         - { regexp: '\s*STATIC_URL =.*',
             line: "STATIC_URL = '{{ STATIC_ASSETS_URL }}'" }
 
-<<<<<<< HEAD
-=======
-        - { regexp: '\s*DEFAULT_DB_TIMEOUT_IN_SECONDS =.*',
-            line: "DEFAULT_DB_TIMEOUT_IN_SECONDS = {{ DEFAULT_DB_TIMEOUT_IN_SECONDS }}" } 
-
->>>>>>> 0e8b2aa3e5e7d9a5b2bf2a640131077fd9b8d999
     - name: add settings.py env vars
       lineinfile:
         dest: "{{ CODE_HOME }}/usaspending_api/settings.py"

--- a/usaspending-deploy/usaspending-api-launch.yml
+++ b/usaspending-deploy/usaspending-api-launch.yml
@@ -173,6 +173,9 @@
         - { regexp: '\s*STATIC_URL =.*',
             line: "STATIC_URL = '{{ STATIC_ASSETS_URL }}'" }
 
+        - { regexp: '\s*DEFAULT_DB_TIMEOUT_IN_SECONDS =.*',
+            line: "DEFAULT_DB_TIMEOUT_IN_SECONDS = '{{ DEFAULT_DB_TIMEOUT_IN_SECONDS }}'" } 
+
     - name: add settings.py env vars
       lineinfile:
         dest: "{{ CODE_HOME }}/usaspending_api/settings.py"

--- a/usaspending-deploy/usaspending-api-launch.yml
+++ b/usaspending-deploy/usaspending-api-launch.yml
@@ -99,6 +99,11 @@
       become: true
       shell: "echo env=DB_R1={{ DB_R1 }} >> {{ CODE_HOME }}/config/uwsgi_db.ini"
 
+    - name: API | add DB_TIMEOUT_IN_SECONDS to uswgi ini
+      when: BUILD_TYPE == 'api'
+      become: true
+      shell: "echo env=DEFAULT_DB_TIMEOUT_IN_SECONDS={{ DEFAULT_DB_TIMEOUT_IN_SECONDS }} >> {{ CODE_HOME }}/config/uwsgi_db.ini"
+
 #===============================  DataDog Configuration  ===============================#
 
     - name: Define Datadog APM env key for this app environment
@@ -172,9 +177,6 @@
 
         - { regexp: '\s*STATIC_URL =.*',
             line: "STATIC_URL = '{{ STATIC_ASSETS_URL }}'" }
-
-        - { regexp: '\s*DEFAULT_DB_TIMEOUT_IN_SECONDS =.*',
-            line: "DEFAULT_DB_TIMEOUT_IN_SECONDS = '{{ DEFAULT_DB_TIMEOUT_IN_SECONDS }}'" } 
 
     - name: add settings.py env vars
       lineinfile:


### PR DESCRIPTION
Set default db timeout for API
The variable is added to the `ansible-vars-[env].yml` https://github.com/fedspendingtransparency/usaspending-config/pull/675