### PR TITLE
updating packer version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 FROM centos:7
 
-ARG packer_version_arg=1.4.3
+ARG packer_version_arg=1.5.6
 ARG ansible_version_arg=2.8.3
 ARG terraform_version_arg=0.12.24
 


### PR DESCRIPTION
HCL2 support has been released so in order to use HCL packer build files we need to upgrade.