### PR TITLE
[OPS-1259] adding cron to USASpending API to manage asg lifecycle

### DIFF
--- a/usaspending-deploy/usaspending-api-image.yml
+++ b/usaspending-deploy/usaspending-api-image.yml
@@ -7,6 +7,8 @@
 
   vars:
     BRANCH: "{{ BRANCH }}"
+    CONFIG_BRANCH: "{{ CONFIG_BRANCH }}"
+    TOOLS_BRANCH: "{{ TOOLS_BRANCH }}"
     REPO: https://github.com/fedspendingtransparency/usaspending-api.git
     CODE_HOME: /data-act/backend
     REQ_DIR: "{{ CODE_HOME }}/requirements"
@@ -49,12 +51,24 @@
         dest: /data-act/config
         force: yes
 
+    - name: checkout config branch
+      become: true
+      shell: git checkout {{ CONFIG_BRANCH }}
+      args:
+        chdir: /data-act/config
+
     - name: pull repo - checkout build-tools repo from git
       become: true
       git:
         repo: https://github.com/fedspendingtransparency/data-act-build-tools.git
         dest: /data-act/build-tools
         force: yes
+
+    - name: checkout tools branch
+      become: true
+      shell: git checkout {{ TOOLS_BRANCH }}
+      args:
+        chdir: /data-act/build-tools
 
     - name: assign ownership of api to ec2-user
       become: true

--- a/usaspending-deploy/usaspending-api-image.yml
+++ b/usaspending-deploy/usaspending-api-image.yml
@@ -48,27 +48,17 @@
       become: true
       git:
         repo: https://pat:{{ pat.contents }}@github.com/fedspendingtransparency/usaspending-config.git
+        version: "{{ CONFIG_BRANCH }}"
         dest: /data-act/config
         force: yes
-
-    - name: checkout config branch
-      become: true
-      shell: git checkout {{ CONFIG_BRANCH }}
-      args:
-        chdir: /data-act/config
 
     - name: pull repo - checkout build-tools repo from git
       become: true
       git:
         repo: https://github.com/fedspendingtransparency/data-act-build-tools.git
+        version: "{{ TOOLS_BRANCH }}"
         dest: /data-act/build-tools
         force: yes
-
-    - name: checkout tools branch
-      become: true
-      shell: git checkout {{ TOOLS_BRANCH }}
-      args:
-        chdir: /data-act/build-tools
 
     - name: assign ownership of api to ec2-user
       become: true

--- a/usaspending-deploy/usaspending-api-image.yml
+++ b/usaspending-deploy/usaspending-api-image.yml
@@ -154,6 +154,21 @@
         hour: "1"
         job: '/usr/bin/freshclam --quiet && /data-act/config/clamav/clamscan_daily.sh'
 
+#===============================  LifeCycle Hook Actions  ===============================#
+
+    - name: chmod 0755 update_lifecycle_status.sh script
+      become: true
+      file:
+        path: /data-act/config/asg_lifecycle_hook/55
+        owner: ec2-user
+        mode: "0755"
+
+    - name : create crontab for periodic check of lifecycle status
+      become: true
+      cron:
+        name: check every minute if instance is terminating and proceed when uwsgi processes are cleared
+        job: '/data-act/config/asg_lifecycle_hook/update_lifecycle_status.sh 2>&1 | /usr/bin/logger -t lifecycle_checks'
+
 #===============================  Logrotate  ===============================#
 
     - name: move logrotate into nightly cron

--- a/usaspending-deploy/usaspending-api-image.yml
+++ b/usaspending-deploy/usaspending-api-image.yml
@@ -159,7 +159,7 @@
     - name: chmod 0755 update_lifecycle_status.sh script
       become: true
       file:
-        path: /data-act/config/asg_lifecycle_hook/55
+        path: /data-act/config/asg_lifecycle_hook/update_lifecycle_status.sh
         owner: ec2-user
         mode: "0755"
 

--- a/usaspending-deploy/usaspending-deploy.py
+++ b/usaspending-deploy/usaspending-deploy.py
@@ -25,8 +25,12 @@ def deploy():
 
     parser = argparse.ArgumentParser()
     parser.add_argument('--deploy_env', required=True, choices=['sandbox', 'dev', 'qat', 'staging', 'prod'])
+    parser.add_argument('--config_branch', required=False, default='master')
+    parser.add_argument('--tools_branch', required=False, default='master')
     args = parser.parse_args()
     deploy_env = args.deploy_env
+    config_branch = args.config_branch
+    tools_branch = args.tools_branch
 
     tfvar_json = open(tfvar_file, "r")
     tfvar_data = json.load(tfvar_json)
@@ -56,6 +60,8 @@ def deploy():
     packer_output = real_time_command([packer_exec_path, 'build', 
                                       '-var', 'environment_ami_tag={}'.format(deploy_env), 
                                       '-var', 'ansible_branch_var={}'.format('master' if deploy_env == 'prod' else deploy_env), 
+                                      '-var', 'config_branch={}'.format(config_branch),
+                                      '-var', 'tools_branch={}'.format(tools_branch),
                                       '-machine-readable', packer_file])
     ami_line = [line for line in packer_output.split('\n') if "amazon-ebs: AMIs were created:" in line][0]
     new_instance_ami = ami_line[ami_line.find('ami-'):ami_line.find('ami-')+21]


### PR DESCRIPTION
adding cron to USASpending API to manage asg lifecycle.

I also adjusted the usaspending packer + ansible build process to use files from the branches selected in the pipeline instead of always using master. This will make it easier for us in the future as well since the status-quo for testing was to make one-off changes to the ansible scripts so they would pull from the correct branch.