### PR TITLE
[OPS-1299] cleaning up user data injection

### DIFF
--- a/broker-deploy/app-instance-image.yml
+++ b/broker-deploy/app-instance-image.yml
@@ -6,6 +6,8 @@
   vars:
     REPO: https://github.com/fedspendingtransparency/data-act-broker-backend.git
     BRANCH: "{{ BRANCH }}"
+    CONFIG_BRANCH: "{{ CONFIG_BRANCH }}"
+    TOOLS_BRANCH: "{{ TOOLS_BRANCH }}"
     CONFIG_HOME: /data-act/config
     DATADOG_YML_PATH: "/data-act/config/datadog/datadog.yaml"
     ansible_python_interpreter: /usr/bin/python3.5
@@ -40,6 +42,7 @@
       become: true
       git:
         repo: https://pat:{{ pat.contents }}@github.com/fedspendingtransparency/data-act-broker-config.git
+        version: "{{ CONFIG_BRANCH }}"
         dest: /data-act/config
         force: "yes"
 
@@ -47,6 +50,7 @@
       become: true
       git:
         repo: https://github.com/fedspendingtransparency/data-act-build-tools.git
+        version: "{{ TOOLS_BRANCH }}"
         dest: /data-act/build-tools
         force: "yes"
 

--- a/broker-deploy/broker-deploy.py
+++ b/broker-deploy/broker-deploy.py
@@ -24,8 +24,12 @@ def deploy():
 
     parser = argparse.ArgumentParser()
     parser.add_argument('--deploy_env', required=True, choices=['sandbox', 'dev', 'qat', 'staging', 'prod'])
+    parser.add_argument('--config_branch', required=False, default='master')
+    parser.add_argument('--tools_branch', required=False, default='master')
     args = parser.parse_args()
     deploy_env = args.deploy_env
+    config_branch = args.config_branch
+    tools_branch = args.tools_branch
 
     tfvar_file = deploy_env + '-variables.tf.json'
     tfvar_json = open(tfvar_file, "r")
@@ -54,7 +58,9 @@ def deploy():
 
     packer_output = real_time_command([packer_exec_path, 'build', 
                                       '-var', 'environment_ami_tag={}'.format(deploy_env), 
-                                      '-var', 'ansible_branch_var={}'.format(ansible_branch_var), 
+                                      '-var', 'ansible_branch_var={}'.format(ansible_branch_var),
+                                      '-var', 'config_branch={}'.format(config_branch),
+                                      '-var', 'tools_branch={}'.format(tools_branch),
                                       '-machine-readable', packer_file])
 
     ami_line = [line for line in packer_output.split('\n') if "amazon-ebs: AMIs were created:" in line][0]

--- a/broker-deploy/broker-deploy.py
+++ b/broker-deploy/broker-deploy.py
@@ -90,7 +90,7 @@ def deploy():
     update_lc_ami(ami_id, tfvar_file, deploy_env)
 
     update_and_copy_startup_script(ansible_branch_var, 'broker', 'broker-start.sh', 'broker-start-api.sh')
-    update_and_copy__startup_script(ansible_branch_var, 'validator', 'broker-start.sh', 'broker-start-val.sh')
+    update_and_copy_startup_script(ansible_branch_var, 'validator', 'broker-start.sh', 'broker-start-val.sh')
 
     print('**************************************************************************')
     print(' Running terraform... ')

--- a/broker-deploy/broker-deploy.py
+++ b/broker-deploy/broker-deploy.py
@@ -83,9 +83,8 @@ def deploy():
     # Add new AMI id to terraform variables
     update_lc_ami(ami_id, tfvar_file, deploy_env)
 
-    # Update Terraform User Data
-    update_startup_script(ansible_branch_var, 'broker', 'broker-start.sh')
-    update_startup_script(ansible_branch_var, 'validator', 'broker-start.sh')
+    update_and_copy_startup_script(ansible_branch_var, 'broker', 'broker-start.sh', 'broker-start-api.sh')
+    update_and_copy__startup_script(ansible_branch_var, 'validator', 'broker-start.sh', 'broker-start-val.sh')
 
     print('**************************************************************************')
     print(' Running terraform... ')
@@ -150,8 +149,8 @@ def update_lc_ami(new_ami='', tfvar_file='variables.tf.json', deploy_env='na'):
 
     return
 
-def update_startup_script(branch, app, file):
-    f = open(file,'r')
+def update_and_copy_startup_script(branch, app, starting_file, new_file):
+    f = open(starting_file,'r')
     filedata = f.read()
     f.close()
 
@@ -165,7 +164,7 @@ def update_startup_script(branch, app, file):
         app_var
     )
 
-    f = open(file,'w')
+    f = open(new_file,'w')
     f.write(newdata)
     f.close()
 

--- a/broker-deploy/broker-deploy.py
+++ b/broker-deploy/broker-deploy.py
@@ -84,8 +84,8 @@ def deploy():
     update_lc_ami(ami_id, tfvar_file, deploy_env)
 
     # Update Terraform User Data
-    update_terraform_user_data(deploy_env, 'api', tf_file)
-    update_terraform_user_data(deploy_env, 'val', tf_file)
+    update_startup_script(ansible_branch_var, 'broker', 'broker-start.sh')
+    update_startup_script(ansible_branch_var, 'validator', 'broker-start.sh')
 
     print('**************************************************************************')
     print(' Running terraform... ')
@@ -150,19 +150,26 @@ def update_lc_ami(new_ami='', tfvar_file='variables.tf.json', deploy_env='na'):
 
     return
 
-def update_terraform_user_data(environment, type, tf_file):
-    f = open(tf_file,'r')
+def update_startup_script(branch, app, file):
+    f = open(file,'r')
     filedata = f.read()
     f.close()
 
-    startup_shell_script = "broker-start-{}.sh".format(environment)
-    newdata = filedata.replace("broker-start-{}.sh".format(type), startup_shell_script)
+    app_var = "APP={}".format(app)
+    branch_var = "BRANCH={}".format(branch)
+    newdata = filedata.replace(
+        "BRANCH=REPLACED_DURING_DEPLOY",
+        branch_var
+    ).replace(
+        "APP=REPLACED_DURING_DEPLOY",
+        app_var
+    )
 
-    f = open(tf_file,'w')
+    f = open(file,'w')
     f.write(newdata)
     f.close()
 
-    print ('Updated {} with user data script for {} {}'.format(tf_file, environment, type))
+    print ('Updated startup script for {} ({})'.format(app, branch))
 
     return
 

--- a/broker-deploy/broker-deploy.py
+++ b/broker-deploy/broker-deploy.py
@@ -83,6 +83,10 @@ def deploy():
     # Add new AMI id to terraform variables
     update_lc_ami(ami_id, tfvar_file, deploy_env)
 
+    # Update Terraform User Data
+    update_terraform_user_data(deploy_env, 'api', tf_file)
+    update_terraform_user_data(deploy_env, 'val', tf_file)
+
     print('**************************************************************************')
     print(' Running terraform... ')
     # Terraform appears to be pretty particular about variable and .tf files, so move the ones we need into
@@ -143,6 +147,22 @@ def update_lc_ami(new_ami='', tfvar_file='variables.tf.json', deploy_env='na'):
     tfvar_json = open(tfvar_file, "w+")
     tfvar_json.write(json.dumps(tfvar_data, indent=4))
     tfvar_json.close()
+
+    return
+
+def update_terraform_user_data(environment, type, tf_file):
+    f = open(tf_file,'r')
+    filedata = f.read()
+    f.close()
+
+    startup_shell_script = "broker-start-{}.sh".format(environment)
+    newdata = filedata.replace("broker-start-{}.sh".format(type), startup_shell_script)
+
+    f = open(tf_file,'w')
+    f.write(newdata)
+    f.close()
+
+    print ('Updated {} with user data script for {} {}'.format(tf_file, environment, type))
 
     return
 

--- a/broker-deploy/broker-deploy.tf
+++ b/broker-deploy/broker-deploy.tf
@@ -97,7 +97,7 @@ resource "aws_launch_configuration" "api-lc" {
 
   # Security group
   security_groups = split(",", var.api_sec_groups)
-  user_data       = var.api_user_data
+  user_data       = file("broker-start-api.sh")
   key_name        = var.key_name
   lifecycle {
     create_before_destroy = true
@@ -112,7 +112,7 @@ resource "aws_launch_configuration" "val-lc" {
 
   # Security group
   security_groups = split(",", var.val_sec_groups)
-  user_data       = var.val_user_data
+  user_data       = file("broker-start-val.sh")
   key_name        = var.key_name
   lifecycle {
     create_before_destroy = true

--- a/usaspending-deploy/usaspending-deploy.py
+++ b/usaspending-deploy/usaspending-deploy.py
@@ -80,8 +80,8 @@ def deploy():
     update_tf_ami(new_instance_ami, tfvar_file)
 
     # Update Terraform User Data
-    update_terraform_user_data(deploy_env, 'api')
-    update_terraform_user_data(deploy_env, 'bd')
+    update_terraform_user_data(deploy_env, 'api', tf_file)
+    update_terraform_user_data(deploy_env, 'bd', tf_file)
 
     print('**************************************************************************')
     print(' Running terraform... ')
@@ -150,7 +150,7 @@ def update_tf_ami(new_ami='', tfvar_file='variables.tf.json'):
     return
 
 
-def update_terraform_user_data(environment, type, tf_file='usaspending-deploy.tf'):
+def update_terraform_user_data(environment, type, tf_file):
     f = open(tf_file,'r')
     filedata = f.read()
     f.close()

--- a/usaspending-deploy/usaspending-deploy.py
+++ b/usaspending-deploy/usaspending-deploy.py
@@ -40,7 +40,8 @@ def deploy():
     tf_state_s3_bucket = tfvar_data['variable']['tf_state_s3_bucket']['default']
     tf_state_s3_path = tfvar_data['variable']['tf_state_s3_path']['default']
     tf_aws_region = tfvar_data['variable']['aws_region']['default']
-    startup_script = "usaspending-start-{}.sh".format(deploy_env)
+    api_startup_script = "usaspending-start-api-{}.sh".format(deploy_env)
+    bd_startup_script = "usaspending-start-bd-{}.sh".format(deploy_env)
 
     # Get Old AMIs, for setting current=False after new one is created
     old_instance_amis = ec2_client.describe_images(Filters=[
@@ -91,7 +92,8 @@ def deploy():
     os.mkdir(deploy_env)
     shutil.copy(tf_file,    deploy_env)
     shutil.copy(tfvar_file, deploy_env)
-    shutil.copy(startup_script, deploy_env)
+    shutil.copy(api_startup_script, deploy_env)
+    shutil.copy(bd_startup_script, deploy_env)
     os.chdir(deploy_env)
 
     # Run Terraform plan and apply
@@ -155,7 +157,7 @@ def update_terraform_user_data(environment, type, tf_file):
     filedata = f.read()
     f.close()
 
-    startup_shell_script = "usaspending-start-{}.sh".format(environment)
+    startup_shell_script = "usaspending-start-{}-{}.sh".format(type, environment)
     newdata = filedata.replace("usaspending-start-{}.sh".format(type), startup_shell_script)
 
     f = open(tf_file,'w')

--- a/usaspending-deploy/usaspending-deploy.py
+++ b/usaspending-deploy/usaspending-deploy.py
@@ -80,7 +80,8 @@ def deploy():
     update_tf_ami(new_instance_ami, tfvar_file)
 
     # Update Terraform User Data
-    update_terraform_user_data(deploy_env)
+    update_terraform_user_data(deploy_env, 'api')
+    update_terraform_user_data(deploy_env, 'bd')
 
     print('**************************************************************************')
     print(' Running terraform... ')
@@ -149,20 +150,19 @@ def update_tf_ami(new_ami='', tfvar_file='variables.tf.json'):
     return
 
 
-def update_terraform_user_data(environment='staging', tf_file='usaspending-deploy.tf'):
+def update_terraform_user_data(environment, type, tf_file='usaspending-deploy.tf'):
     f = open(tf_file,'r')
     filedata = f.read()
     f.close()
 
-    # environment = prod, staging, dev, or sandbox
     startup_shell_script = "usaspending-start-{}.sh".format(environment)
-    newdata = filedata.replace("usaspending-start-staging.sh", startup_shell_script)
+    newdata = filedata.replace("usaspending-start-{}.sh".format(type), startup_shell_script)
 
     f = open(tf_file,'w')
     f.write(newdata)
     f.close()
 
-    print ('Updated ' + tf_file + ' with user data script for ' + environment)
+    print ('Updated {} with user data script for {} {}'.format(tf_file, environment, type))
 
     return
 

--- a/usaspending-deploy/usaspending-deploy.tf
+++ b/usaspending-deploy/usaspending-deploy.tf
@@ -65,7 +65,7 @@ resource "aws_launch_configuration" "api_lc" {
   instance_type        = var.api_instance_type
   iam_instance_profile = var.iam_profile
   security_groups      = split(",", var.sec_groups)
-  user_data            = file("usaspending-start-staging.sh")
+  user_data            = file("usaspending-start-api.sh")
   key_name             = var.key_name
   lifecycle {
     create_before_destroy = true
@@ -236,7 +236,7 @@ resource "aws_launch_configuration" "bd_lc" {
   instance_type        = var.bd_instance_type
   iam_instance_profile = var.iam_profile
   security_groups      = split(",", var.sec_groups)
-  user_data            = var.bd_user_data
+  user_data            = file("usaspending-start-bd.sh")
   key_name             = var.key_name
   lifecycle {
     create_before_destroy = true


### PR DESCRIPTION
adjusting the output of the launch ansible script to write to system log increases the length of the script by quite a bit. Enough where it is too clunky to lug around in a terraform variable.

Refactoring a bit to have both the api and bulk downloader launch scripts / user data be files that can then be referenced by terraform.