### PR TITLE
ops-1001 - moved from sum to max in queue metric

### DIFF
--- a/usaspending-deploy/usaspending-deploy.tf
+++ b/usaspending-deploy/usaspending-deploy.tf
@@ -306,7 +306,7 @@ resource "aws_cloudwatch_metric_alarm" "bd_sqs_queue_low" {
       metric_name = "GroupInServiceInstances"
       namespace   = "AWS/AutoScaling"
       period      = "300"
-      stat        = "Average"
+      stat        = "Maximum"
 
       dimensions = {
         AutoScalingGroupName = aws_autoscaling_group.bd_asg.name
@@ -355,7 +355,7 @@ resource "aws_cloudwatch_metric_alarm" "bd_sqs_queue_high" {
       metric_name = "GroupInServiceInstances"
       namespace   = "AWS/AutoScaling"
       period      = "300"
-      stat        = "Sum"
+      stat        = "Maximum"
 
       dimensions = {
         AutoScalingGroupName = aws_autoscaling_group.bd_asg.name


### PR DESCRIPTION
Just realized I screwed up the queue metric and used sum instead of maximum. It basically set the sum at 5 instances indefinitely, but when I tested in sandbox, I blasted the queue with a ton of messages scaling still worked. I scaled up prod for now just in case we get blasted again. 