### PR TITLE
adding optional path to cloudfront invalidation script

### DIFF
--- a/invalidate-url.py
+++ b/invalidate-url.py
@@ -7,8 +7,10 @@ import os
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--url', required=True, type=str)
+parser.add_argument('--path', required=False, type=str, default='/*')
 args = parser.parse_args()
 url = args.url
+path = args.path
 
 # Requires AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables available
 session = boto3.Session(region_name='us-east-1')
@@ -25,7 +27,7 @@ for distribution in distributions:
 
 timestart = time.time()
 invalidation = client.create_invalidation(DistributionId=dist_id, 
-    InvalidationBatch={'Paths': {'Quantity': 1,'Items': ['/*',]},
+    InvalidationBatch={'Paths': {'Quantity': 1,'Items': [path,]},
     'CallerReference': str(timestart)})
 invalidation_id = invalidation['Invalidation']['Id']
 print('Creating invalidation for %s (id: %s)...' % (url, invalidation_id))


### PR DESCRIPTION
Adding the ability to specify paths if we need to invalidate only a single file or pattern, instead of the whole distribution. The default behavior will not change how this script functions currently.