### PR TITLE
Fix/pin pip version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,6 @@ ARG terraform_version_arg=0.12.31
 ARG terragrunt_version_arg=0.25.4
 ARG ami_manager_arg=0.8.0
 ARG node_version_arg=12.x
-ARG pip_version=21.1.3
 
 ENV PACKER_VERSION=${packer_version_arg}
 ENV ANSIBLE_VERSION=${ansible_version_arg}
@@ -16,7 +15,6 @@ ENV TERRAFORM_VERSION=${terraform_version_arg}
 ENV TERRAGRUNT_VERSION=${terragrunt_version_arg}
 ENV AMI_MANAGER_VERSION=${ami_manager_arg}
 ENV NODE_VERSION=${node_version_arg}
-ENV PIP_INSTALL_VERSION=${pip_version}
 
 # set up nodejs repo
 RUN curl -sL https://rpm.nodesource.com/setup_${NODE_VERSION} | bash -
@@ -48,7 +46,7 @@ RUN unzip -j /tmp/packer-post-processor-amazon-ami-management_${AMI_MANAGER_VERS
 
 # install ansible
 # RUN pip3.6 install --upgrade pip==21.1.3
-RUN python3 -m pip install --upgrade pip==${PIP_INSTALL_VERSION}
+RUN python3 -m pip install --upgrade pip==21.1.3
 RUN pip3 install ansible==${ANSIBLE_VERSION}
 
 # install terraform and create an symlink on /usr/local

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,8 @@ RUN cd ~/.packer.d/plugins
 RUN unzip -j /tmp/packer-post-processor-amazon-ami-management_${AMI_MANAGER_VERSION}_linux_amd64.zip -d ~/.packer.d/plugins
 
 # install ansible
-RUN pip3.6 install --upgrade pip==21.1.3
+# RUN pip3.6 install --upgrade pip==21.1.3
+RUN python3 -m pip3 install --upgrade pip==21.1.3
 RUN pip3 install ansible==${ANSIBLE_VERSION}
 
 # install terraform and create an symlink on /usr/local

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ RUN unzip -j /tmp/packer-post-processor-amazon-ami-management_${AMI_MANAGER_VERS
 
 # install ansible
 # RUN pip3.6 install --upgrade pip==21.1.3
-RUN python3 -m pip3 install --upgrade pip==21.1.3
+RUN python3 -m pip install --upgrade pip==21.1.3
 RUN pip3 install ansible==${ANSIBLE_VERSION}
 
 # install terraform and create an symlink on /usr/local

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ RUN cd ~/.packer.d/plugins
 RUN unzip -j /tmp/packer-post-processor-amazon-ami-management_${AMI_MANAGER_VERSION}_linux_amd64.zip -d ~/.packer.d/plugins
 
 # install ansible
-RUN pip3.6 install pip=${PIP_VERSION}
+RUN pip3.6 install pip==${PIP_VERSION}
 RUN pip3 install ansible==${ANSIBLE_VERSION}
 
 # install terraform and create an symlink on /usr/local

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ RUN cd ~/.packer.d/plugins
 RUN unzip -j /tmp/packer-post-processor-amazon-ami-management_${AMI_MANAGER_VERSION}_linux_amd64.zip -d ~/.packer.d/plugins
 
 # install ansible
-RUN pip3.6 install pip==${PIP_VERSION}
+RUN pip3.6 install --upgrade pip==${PIP_VERSION}
 RUN pip3 install ansible==${ANSIBLE_VERSION}
 
 # install terraform and create an symlink on /usr/local

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ ENV TERRAFORM_VERSION=${terraform_version_arg}
 ENV TERRAGRUNT_VERSION=${terragrunt_version_arg}
 ENV AMI_MANAGER_VERSION=${ami_manager_arg}
 ENV NODE_VERSION=${node_version_arg}
-ENV PIP_VERSION=${pip_version}
+ENV PIP_INSTALL_VERSION=${pip_version}
 
 # set up nodejs repo
 RUN curl -sL https://rpm.nodesource.com/setup_${NODE_VERSION} | bash -
@@ -48,7 +48,7 @@ RUN unzip -j /tmp/packer-post-processor-amazon-ami-management_${AMI_MANAGER_VERS
 
 # install ansible
 # RUN pip3.6 install --upgrade pip==21.1.3
-RUN python3 -m pip install --upgrade pip==21.1.3
+RUN python3 -m pip install --upgrade pip==${PIP_INSTALL_VERSION}
 RUN pip3 install ansible==${ANSIBLE_VERSION}
 
 # install terraform and create an symlink on /usr/local

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ ARG terraform_version_arg=0.12.31
 ARG terragrunt_version_arg=0.25.4
 ARG ami_manager_arg=0.8.0
 ARG node_version_arg=12.x
+ARG pip_install_version=21.1.3
 
 ENV PACKER_VERSION=${packer_version_arg}
 ENV ANSIBLE_VERSION=${ansible_version_arg}
@@ -15,6 +16,7 @@ ENV TERRAFORM_VERSION=${terraform_version_arg}
 ENV TERRAGRUNT_VERSION=${terragrunt_version_arg}
 ENV AMI_MANAGER_VERSION=${ami_manager_arg}
 ENV NODE_VERSION=${node_version_arg}
+ENV PYTHON_PIP_VERSION=${pip_install_version}
 
 # set up nodejs repo
 RUN curl -sL https://rpm.nodesource.com/setup_${NODE_VERSION} | bash -
@@ -46,7 +48,7 @@ RUN unzip -j /tmp/packer-post-processor-amazon-ami-management_${AMI_MANAGER_VERS
 
 # install ansible
 # RUN pip3.6 install --upgrade pip==21.1.3
-RUN python3 -m pip install --upgrade pip==21.1.3
+RUN pip3 install --no-cache-dir --upgrade pip=${PYTHON_PIP_VERSION}
 RUN pip3 install ansible==${ANSIBLE_VERSION}
 
 # install terraform and create an symlink on /usr/local

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ RUN cd ~/.packer.d/plugins
 RUN unzip -j /tmp/packer-post-processor-amazon-ami-management_${AMI_MANAGER_VERSION}_linux_amd64.zip -d ~/.packer.d/plugins
 
 # install ansible
-RUN pip3.6 install --upgrade pip==${PIP_VERSION}
+RUN pip3.6 install --upgrade pip==21.1.3
 RUN pip3 install ansible==${ANSIBLE_VERSION}
 
 # install terraform and create an symlink on /usr/local

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ ARG terraform_version_arg=0.12.31
 ARG terragrunt_version_arg=0.25.4
 ARG ami_manager_arg=0.8.0
 ARG node_version_arg=12.x
+ARG pip_version=21.0.1
 
 ENV PACKER_VERSION=${packer_version_arg}
 ENV ANSIBLE_VERSION=${ansible_version_arg}
@@ -15,6 +16,7 @@ ENV TERRAFORM_VERSION=${terraform_version_arg}
 ENV TERRAGRUNT_VERSION=${terragrunt_version_arg}
 ENV AMI_MANAGER_VERSION=${ami_manager_arg}
 ENV NODE_VERSION=${node_version_arg}
+ENV PIP_VERSION=${pip_version}
 
 # set up nodejs repo
 RUN curl -sL https://rpm.nodesource.com/setup_${NODE_VERSION} | bash -
@@ -45,7 +47,7 @@ RUN cd ~/.packer.d/plugins
 RUN unzip -j /tmp/packer-post-processor-amazon-ami-management_${AMI_MANAGER_VERSION}_linux_amd64.zip -d ~/.packer.d/plugins
 
 # install ansible
-RUN pip3.6 install pip --upgrade
+RUN pip3.6 install pip=${PIP_VERSION}
 RUN pip3 install ansible==${ANSIBLE_VERSION}
 
 # install terraform and create an symlink on /usr/local

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ RUN unzip -j /tmp/packer-post-processor-amazon-ami-management_${AMI_MANAGER_VERS
 
 # install ansible
 # RUN pip3.6 install --upgrade pip==21.1.3
-RUN pip3 install --no-cache-dir --upgrade pip=${PYTHON_PIP_VERSION}
+RUN pip3 install --no-cache-dir --upgrade pip==${PYTHON_PIP_VERSION}
 RUN pip3 install ansible==${ANSIBLE_VERSION}
 
 # install terraform and create an symlink on /usr/local

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ARG terraform_version_arg=0.12.31
 ARG terragrunt_version_arg=0.25.4
 ARG ami_manager_arg=0.8.0
 ARG node_version_arg=12.x
-ARG pip_version=21.0.1
+ARG pip_version=21.1.3
 
 ENV PACKER_VERSION=${packer_version_arg}
 ENV ANSIBLE_VERSION=${ansible_version_arg}


### PR DESCRIPTION
We need to pip this pip version since the newest pip is not compatible with Ansible. 

Note: This PR does NOT contain the IUS fixes, so it will just install the generic version of python3 instead of python3.6u. That will be in a future PR. 